### PR TITLE
Makefile: convert build & run to PHONY targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 TAG=dbt-data-runner
 
+.PHONY: build
 build:
 	docker build --build-arg COREDW_RO_PASSWORD=${COREDW_RO_PASSWORD} -t $(TAG) .
 
+.PHONY: run
 run:
 	touch $(HOME)/.gitconfig
 	touch $(HOME)/.bash_history


### PR DESCRIPTION
Standard Make targets represent a file. In this case, if file named `build` or `run` were to be created (ex. `touch build`), then those Make targets would cease to function properly. By using the `PHONY` target, you can identify targets as "phony" which means that Make will skip any file related tests, thus it will execute the target recipe each time.